### PR TITLE
Fix the route transition by moving them from layout views to the App root in Afterwork

### DIFF
--- a/services/afterwork/src/App.vue
+++ b/services/afterwork/src/App.vue
@@ -1,5 +1,15 @@
 <template>
-  <router-view />
+  <!--<router-view />-->
+
+  <router-view v-slot="{ Component }">
+    <transition appear enter-active-class="animated fadeIn slow" leave-active-class="animated fadeOut" mode="out-in">
+      <component :is="Component" />
+    </transition>
+  </router-view>
+
+  <!--
+  <TransitionRouterView />
+  -->
 </template>
 
 <script setup lang="ts">

--- a/services/afterwork/src/layouts/MainLayout.vue
+++ b/services/afterwork/src/layouts/MainLayout.vue
@@ -18,10 +18,7 @@
     </q-header>
 
     <q-page-container>
-      <!-- <transition appear enter-active-class="animated slideInRight" leave-active-class="animated slideOutRight" -->
-      <!-- mode="out-in"> -->
-      <transition-router-view />
-      <!-- </transition> -->
+      <router-view />
     </q-page-container>
 
     <q-footer reveal bordered class="bg-white text-brand">
@@ -91,7 +88,6 @@
 <script setup lang="ts">
 // import { ref } from 'vue';
 import { useRoute } from "vue-router";
-import TransitionRouterView from "router/TransitionRouterView.vue"
 // import EssentialLink, { EssentialLinkProps } from 'components/EssentialLink.vue';
 //
 // defineOptions({

--- a/services/afterwork/src/layouts/OnboardingLayout.vue
+++ b/services/afterwork/src/layouts/OnboardingLayout.vue
@@ -10,10 +10,7 @@
     </q-header>
 
     <q-page-container>
-      <!-- <transition appear enter-active-class="animated slideInRight" leave-active-class="animated slideOutRight" -->
-      <!-- mode="out-in"> -->
-      <transition-router-view />
-      <!-- </transition> -->
+      <router-view />
     </q-page-container>
 
   </q-layout>
@@ -23,6 +20,5 @@
 import ZKGoBackButton from "views/ZKGoBackButton.vue";
 import ZKHelpButton from "views/ZKHelpButton.vue";
 import { OnboardingLayoutProps } from "model/props";
-import TransitionRouterView from "router/TransitionRouterView.vue"
 const props = withDefaults(defineProps<OnboardingLayoutProps>(), { hasGoBackButton: true, hasHelpButton: true })
 </script>

--- a/services/afterwork/src/layouts/PostLayout.vue
+++ b/services/afterwork/src/layouts/PostLayout.vue
@@ -18,10 +18,7 @@
     </q-header>
 
     <q-page-container>
-      <!-- <transition appear enter-active-class="animated slideInRight" leave-active-class="animated slideOutRight" -->
-      <!-- mode="out-in"> -->
-      <transition-router-view />
-      <!-- </transition> -->
+      <router-view />
     </q-page-container>
 
     <q-footer reveal bordered class="bg-white text-brand">
@@ -91,7 +88,6 @@
 <script setup lang="ts">
 // import { ref } from 'vue';
 import { useRoute } from "vue-router";
-import TransitionRouterView from "router/TransitionRouterView.vue"
 // import EssentialLink, { EssentialLinkProps } from 'components/EssentialLink.vue';
 //
 // defineOptions({


### PR DESCRIPTION
Currently the route animation transitions would display an error when you transition from one view to another. This patch moves the route transitions from the following layout files to the root `App.vue`:

- MainLayout.vue
- OnboardingLayout.vue 
- PostLayout.vue
