### PR TITLE
Add delete comment API

### DIFF
--- a/services/agora/src/api/api.ts
+++ b/services/agora/src/api/api.ts
@@ -687,7 +687,7 @@ export interface ApiV1UserFetchUserProfilePost200Response {
      * @type {number}
      * @memberof ApiV1UserFetchUserProfilePost200Response
      */
-    'postCount': number;
+    'activePostCount': number;
     /**
      * 
      * @type {string}

--- a/services/agora/src/api/api.ts
+++ b/services/agora/src/api/api.ts
@@ -687,12 +687,6 @@ export interface ApiV1UserFetchUserProfilePost200Response {
      * @type {number}
      * @memberof ApiV1UserFetchUserProfilePost200Response
      */
-    'commentCount': number;
-    /**
-     * 
-     * @type {number}
-     * @memberof ApiV1UserFetchUserProfilePost200Response
-     */
     'postCount': number;
     /**
      * 

--- a/services/agora/src/api/api.ts
+++ b/services/agora/src/api/api.ts
@@ -252,6 +252,19 @@ export interface ApiV1CommentCreatePostRequest {
 /**
  * 
  * @export
+ * @interface ApiV1CommentDeletePostRequest
+ */
+export interface ApiV1CommentDeletePostRequest {
+    /**
+     * 
+     * @type {string}
+     * @memberof ApiV1CommentDeletePostRequest
+     */
+    'commentSlugId': string;
+}
+/**
+ * 
+ * @export
  * @interface ApiV1CommentFetchCommentsByPostSlugIdPostRequest
  */
 export interface ApiV1CommentFetchCommentsByPostSlugIdPostRequest {
@@ -961,6 +974,45 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
+         * @param {ApiV1CommentDeletePostRequest} apiV1CommentDeletePostRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiV1CommentDeletePost: async (apiV1CommentDeletePostRequest: ApiV1CommentDeletePostRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'apiV1CommentDeletePostRequest' is not null or undefined
+            assertParamExists('apiV1CommentDeletePost', 'apiV1CommentDeletePostRequest', apiV1CommentDeletePostRequest)
+            const localVarPath = `/api/v1/comment/delete`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(apiV1CommentDeletePostRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @param {ApiV1CommentFetchCommentsByPostSlugIdPostRequest} apiV1CommentFetchCommentsByPostSlugIdPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -1485,6 +1537,18 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @param {ApiV1CommentDeletePostRequest} apiV1CommentDeletePostRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiV1CommentDeletePost(apiV1CommentDeletePostRequest: ApiV1CommentDeletePostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1CommentDeletePost(apiV1CommentDeletePostRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1CommentDeletePost']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
          * @param {ApiV1CommentFetchCommentsByPostSlugIdPostRequest} apiV1CommentFetchCommentsByPostSlugIdPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -1681,6 +1745,15 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
+         * @param {ApiV1CommentDeletePostRequest} apiV1CommentDeletePostRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiV1CommentDeletePost(apiV1CommentDeletePostRequest: ApiV1CommentDeletePostRequest, options?: any): AxiosPromise<void> {
+            return localVarFp.apiV1CommentDeletePost(apiV1CommentDeletePostRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
          * @param {ApiV1CommentFetchCommentsByPostSlugIdPostRequest} apiV1CommentFetchCommentsByPostSlugIdPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -1847,6 +1920,17 @@ export class DefaultApi extends BaseAPI {
      */
     public apiV1CommentCreatePost(apiV1CommentCreatePostRequest: ApiV1CommentCreatePostRequest, options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).apiV1CommentCreatePost(apiV1CommentCreatePostRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {ApiV1CommentDeletePostRequest} apiV1CommentDeletePostRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public apiV1CommentDeletePost(apiV1CommentDeletePostRequest: ApiV1CommentDeletePostRequest, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiV1CommentDeletePost(apiV1CommentDeletePostRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/services/agora/src/components/post/PostDetails.vue
+++ b/services/agora/src/components/post/PostDetails.vue
@@ -58,7 +58,7 @@
 
         <div v-if="!compactMode" ref="commentSectionRef">
           <CommentSection :key="commentCountOffset" :post-slug-id="extendedPostData.metadata.postSlugId"
-            :initial-comment-slug-id="commentSlugId" />
+            :initial-comment-slug-id="commentSlugId" @deleted="decrementCommentCount()" />
         </div>
       </div>
     </ZKHoverEffect>
@@ -124,6 +124,10 @@ onMounted(() => {
     }, 100);
   }
 });
+
+function decrementCommentCount() {
+  commentCountOffset.value -= 1;
+}
 
 function scrollToCommentSection() {
   console.log(commentSectionRef.value);

--- a/services/agora/src/components/post/views/CommentActionBar.vue
+++ b/services/agora/src/components/post/views/CommentActionBar.vue
@@ -35,6 +35,8 @@ import { type CommentItem, type VotingAction } from "src/shared/types/zod";
 import { useAuthenticationStore } from "src/stores/authentication";
 import { useDialog } from "src/utils/ui/dialog";
 
+const emit = defineEmits(["deleted"])
+
 const props = defineProps<{
   commentItem: CommentItem;
   postSlugId: string;
@@ -110,7 +112,16 @@ function shareButtonClicked() {
 }
 
 function optionButtonClicked() {
-  bottomSheet.showCommentOptionSelector();
+  const deleteCommentCallback = (deleted: boolean) => {
+    if (deleted) {
+      emit("deleted");
+    }
+  }
+
+  bottomSheet.showCommentOptionSelector(
+    props.commentItem.commentSlugId,
+    props.commentItem.userName,
+    deleteCommentCallback);
 }
 
 async function castPersonalVote(

--- a/services/agora/src/components/post/views/CommentSection.vue
+++ b/services/agora/src/components/post/views/CommentSection.vue
@@ -11,7 +11,7 @@
         <div v-for="commentItem in commentItems" :id="commentItem.commentSlugId" :key="commentItem.commentSlugId">
           <CommentSingle :comment-item="commentItem" :post-slug-id="postSlugId"
             :highlight="initialCommentSlugId == commentItem.commentSlugId"
-            :comment-slug-id-liked-map="commentSlugIdLikedMap" />
+            :comment-slug-id-liked-map="commentSlugIdLikedMap" @deleted="deletedComment()" />
 
           <Divider :style="{ width: '100%' }" />
         </div>
@@ -42,6 +42,8 @@ import { useBackendVoteApi } from "src/utils/api/vote";
 import { useAuthenticationStore } from "src/stores/authentication";
 import { type CommentItem } from "src/shared/types/zod";
 
+const emit = defineEmits(["deleted"])
+
 const props = defineProps<{
   postSlugId: string;
   initialCommentSlugId: string;
@@ -63,6 +65,10 @@ fetchCommentList();
 onMounted(() => {
   fetchPersonalLikes();
 });
+
+function deletedComment() {
+  emit("deleted");
+}
 
 async function fetchPersonalLikes() {
   if (isAuthenticated.value) {

--- a/services/agora/src/components/post/views/CommentSingle.vue
+++ b/services/agora/src/components/post/views/CommentSingle.vue
@@ -1,7 +1,10 @@
 <!-- eslint-disable vue/no-v-html -->
 <template>
   <div>
-    <div class="contentLayout">
+    <div v-if="deleted" class="deletedMessage">
+      Deleted
+    </div>
+    <div v-if="!deleted" class="contentLayout">
       <div class="metadata">
         <UserAvatar :user-name="commentItem.userName" :size="40" class="avatarIcon" />
 
@@ -24,7 +27,7 @@
 
         <div class="actionBarPaddings">
           <CommentActionBar :comment-item="commentItem" :post-slug-id="postSlugId"
-            :comment-slug-id-liked-map="commentSlugIdLikedMap" />
+            :comment-slug-id-liked-map="commentSlugIdLikedMap" @deleted="deletedComment()" />
         </div>
       </div>
     </div>
@@ -36,6 +39,9 @@ import CommentActionBar from "./CommentActionBar.vue";
 import UserAvatar from "src/components/account/UserAvatar.vue";
 import { formatTimeAgo } from "@vueuse/core";
 import type { CommentItem } from "src/shared/types/zod";
+import { ref } from "vue";
+
+const emit = defineEmits(["deleted"])
 
 defineProps<{
   commentItem: CommentItem;
@@ -43,6 +49,14 @@ defineProps<{
   highlight: boolean;
   commentSlugIdLikedMap: Map<string, "like" | "dislike">;
 }>();
+
+const deleted = ref(false);
+
+function deletedComment() {
+  deleted.value = true
+  emit("deleted");
+}
+
 </script>
 
 <style scoped lang="scss">
@@ -79,5 +93,10 @@ defineProps<{
   font-size: 0.8rem;
   display: flex;
   flex-direction: column;
+}
+
+.deletedMessage {
+  display: flex;
+  justify-content: center;
 }
 </style>

--- a/services/agora/src/components/profile/UserCommentList.vue
+++ b/services/agora/src/components/profile/UserCommentList.vue
@@ -39,9 +39,9 @@
 import { useElementVisibility, useTimeAgo } from "@vueuse/core";
 import { useUserStore } from "src/stores/user";
 import ZKHoverEffect from "../ui-library/ZKHoverEffect.vue";
-import { ref, watch } from "vue";
+import { onMounted, ref, watch } from "vue";
 
-const { profileData, loadMoreUserComments } = useUserStore();
+const { profileData, loadMoreUserComments, loadUserProfile } = useUserStore();
 
 const endOfFeed = ref(false);
 let isExpandingPosts = false;
@@ -49,8 +49,15 @@ let isExpandingPosts = false;
 const bottomOfPostDiv = ref(null);
 const targetIsVisible = useElementVisibility(bottomOfPostDiv);
 
+let isLoaded = false;
+
+onMounted(async () => {
+  await loadUserProfile();
+  isLoaded = true;
+});
+
 watch(targetIsVisible, async () => {
-  if (targetIsVisible.value && !isExpandingPosts && !endOfFeed.value) {
+  if (targetIsVisible.value && !isExpandingPosts && !endOfFeed.value && isLoaded) {
     isExpandingPosts = true;
 
     const response = await loadMoreUserComments();

--- a/services/agora/src/components/profile/UserPostList.vue
+++ b/services/agora/src/components/profile/UserPostList.vue
@@ -19,10 +19,10 @@
 import { useElementVisibility } from "@vueuse/core";
 import PostDetails from "src/components/post/PostDetails.vue";
 import { useUserStore } from "src/stores/user";
-import { ref, watch } from "vue";
+import { onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 
-const { loadMoreUserPosts, profileData } = useUserStore();
+const { loadUserProfile, loadMoreUserPosts, profileData } = useUserStore();
 
 const router = useRouter();
 
@@ -32,8 +32,15 @@ let isExpandingPosts = false;
 const bottomOfPostDiv = ref(null);
 const targetIsVisible = useElementVisibility(bottomOfPostDiv);
 
+let isLoaded = false;
+
+onMounted(async () => {
+  await loadUserProfile();
+  isLoaded = true;
+});
+
 watch(targetIsVisible, async () => {
-  if (targetIsVisible.value && !isExpandingPosts && !endOfFeed.value) {
+  if (targetIsVisible.value && !isExpandingPosts && !endOfFeed.value && isLoaded) {
     isExpandingPosts = true;
 
     const response = await loadMoreUserPosts();

--- a/services/agora/src/pages/user-profile/index.vue
+++ b/services/agora/src/pages/user-profile/index.vue
@@ -11,7 +11,6 @@
 
       <div class="profileMetadataBar">
         <div>{{ profileData.postCount }} conservations <span class="dotPadding">•</span></div>
-        <div>{{ profileData.commentCount }} opinions <span class="dotPadding">•</span></div>
         <div>{{ getDateString(new Date(profileData.createdAt)) }}</div>
       </div>
 

--- a/services/agora/src/pages/user-profile/index.vue
+++ b/services/agora/src/pages/user-profile/index.vue
@@ -36,7 +36,7 @@ import Tab from "primevue/tab";
 import TabList from "primevue/tablist";
 import UserAvatar from "src/components/account/UserAvatar.vue";
 import { useUserStore } from "src/stores/user";
-import { onMounted, ref, watch } from "vue";
+import { ref, watch } from "vue";
 import { useRoute } from "vue-router";
 import { getDateString } from "src/utils/common";
 
@@ -47,12 +47,6 @@ const currentTab = ref(0);
 const route = useRoute();
 
 applyCurrentTab();
-
-const { loadUserProfile } = useUserStore();
-
-onMounted(() => {
-  loadUserProfile();
-});
 
 watch(route, () => {
   applyCurrentTab();

--- a/services/agora/src/pages/user-profile/index.vue
+++ b/services/agora/src/pages/user-profile/index.vue
@@ -10,7 +10,7 @@
       </div>
 
       <div class="profileMetadataBar">
-        <div>{{ profileData.postCount }} conservations <span class="dotPadding">•</span></div>
+        <div>{{ profileData.activePostCount }} conservations <span class="dotPadding">•</span></div>
         <div>{{ getDateString(new Date(profileData.createdAt)) }}</div>
       </div>
 

--- a/services/agora/src/shared/types/dto.ts
+++ b/services/agora/src/shared/types/dto.ts
@@ -139,7 +139,7 @@ export class Dto {
         chosenOption: zodVotingAction
     }).strict();
     static fetchUserProfileResponse = z.object({
-        postCount: z.number().gte(0),
+        activePostCount: z.number().gte(0),
         createdAt: z.date(),
         userName: zodUserName,
     }).strict();

--- a/services/agora/src/shared/types/dto.ts
+++ b/services/agora/src/shared/types/dto.ts
@@ -139,7 +139,6 @@ export class Dto {
         chosenOption: zodVotingAction
     }).strict();
     static fetchUserProfileResponse = z.object({
-        commentCount: z.number().gte(0),
         postCount: z.number().gte(0),
         createdAt: z.date(),
         userName: zodUserName,

--- a/services/agora/src/shared/types/dto.ts
+++ b/services/agora/src/shared/types/dto.ts
@@ -160,6 +160,11 @@ export class Dto {
             postSlugId: zodSlugId
         })
         .strict();
+    static deleteCommentBySlugIdRequest = z
+        .object({
+            commentSlugId: zodSlugId
+        })
+        .strict();
 }
 
 export type AuthenticateRequestBody = z.infer<

--- a/services/agora/src/stores/user.ts
+++ b/services/agora/src/stores/user.ts
@@ -66,7 +66,6 @@ export function useUserStore() {
   }
 
   function resetUserProfile() {
-    console.log("reset user profile");
     profileData.value = emptyProfile;
   }
 

--- a/services/agora/src/stores/user.ts
+++ b/services/agora/src/stores/user.ts
@@ -7,7 +7,6 @@ export function useUserStore() {
   const { fetchUserProfile, fetchUserPosts, fetchUserComments } = useBackendUserApi();
 
   interface UserProfile {
-    commentCount: number;
     postCount: number;
     createdAt: Date;
     userName: string;
@@ -16,7 +15,6 @@ export function useUserStore() {
   }
 
   const emptyProfile: UserProfile = {
-    commentCount: 0,
     postCount: 0,
     createdAt: new Date(),
     userName: "",
@@ -28,7 +26,6 @@ export function useUserStore() {
 
 
   async function loadUserProfile() {
-
     const [userProfile, userPosts, userComments] = await Promise.all([
       fetchUserProfile(),
       fetchUserPosts(undefined),
@@ -36,7 +33,6 @@ export function useUserStore() {
 
     if (userProfile && userPosts && userComments) {
       profileData.value = {
-        commentCount: userProfile.commentCount,
         postCount: userProfile.postCount,
         createdAt: userProfile.createdAt,
         userName: userProfile.userName,
@@ -60,7 +56,7 @@ export function useUserStore() {
 
   async function loadMoreUserComments() {
     let lastCommentSlugId: undefined | string = undefined;
-    if (profileData.value.userPostList.length > 0) {
+    if (profileData.value.userCommentList.length > 0) {
       lastCommentSlugId = profileData.value.userCommentList.at(-1).commentItem.commentSlugId;
     }
 
@@ -71,6 +67,7 @@ export function useUserStore() {
   }
 
   function resetUserProfile() {
+    console.log("reset user profile");
     profileData.value = emptyProfile;
   }
 

--- a/services/agora/src/stores/user.ts
+++ b/services/agora/src/stores/user.ts
@@ -24,7 +24,6 @@ export function useUserStore() {
 
   const profileData = useStorage("user-profile-data", emptyProfile);
 
-
   async function loadUserProfile() {
     const [userProfile, userPosts, userComments] = await Promise.all([
       fetchUserProfile(),

--- a/services/agora/src/stores/user.ts
+++ b/services/agora/src/stores/user.ts
@@ -7,7 +7,7 @@ export function useUserStore() {
   const { fetchUserProfile, fetchUserPosts, fetchUserComments } = useBackendUserApi();
 
   interface UserProfile {
-    postCount: number;
+    activePostCount: number;
     createdAt: Date;
     userName: string;
     userPostList: ExtendedPost[];
@@ -15,7 +15,7 @@ export function useUserStore() {
   }
 
   const emptyProfile: UserProfile = {
-    postCount: 0,
+    activePostCount: 0,
     createdAt: new Date(),
     userName: "",
     userPostList: [],
@@ -33,7 +33,7 @@ export function useUserStore() {
 
     if (userProfile && userPosts && userComments) {
       profileData.value = {
-        postCount: userProfile.postCount,
+        activePostCount: userProfile.activePostCount,
         createdAt: userProfile.createdAt,
         userName: userProfile.userName,
         userPostList: userPosts,

--- a/services/agora/src/utils/api/user.ts
+++ b/services/agora/src/utils/api/user.ts
@@ -33,7 +33,7 @@ export function useBackendUserApi() {
       });
 
       return {
-        postCount: response.data.postCount,
+        activePostCount: response.data.activePostCount,
         createdAt: new Date(response.data.createdAt),
         userName: response.data.userName,
       };

--- a/services/agora/src/utils/api/user.ts
+++ b/services/agora/src/utils/api/user.ts
@@ -33,7 +33,6 @@ export function useBackendUserApi() {
       });
 
       return {
-        commentCount: response.data.commentCount,
         postCount: response.data.postCount,
         createdAt: new Date(response.data.createdAt),
         userName: response.data.userName,

--- a/services/api/database/flyway/V0000__wooden_hellfire_club.sql
+++ b/services/api/database/flyway/V0000__wooden_hellfire_club.sql
@@ -260,8 +260,9 @@ CREATE TABLE IF NOT EXISTS "user" (
 	"user_name" varchar(23) NOT NULL,
 	"is_anonymous" boolean DEFAULT true NOT NULL,
 	"show_flagged_content" boolean DEFAULT false NOT NULL,
-	"post_count" integer DEFAULT 0 NOT NULL,
-	"comment_count" integer DEFAULT 0 NOT NULL,
+	"active_post_count" integer DEFAULT 0 NOT NULL,
+	"total_post_count" integer DEFAULT 0 NOT NULL,
+	"total_comment_count" integer DEFAULT 0 NOT NULL,
 	"created_at" timestamp (0) DEFAULT now() NOT NULL,
 	"updated_at" timestamp (0) DEFAULT now() NOT NULL,
 	CONSTRAINT "user_user_name_unique" UNIQUE("user_name")

--- a/services/api/drizzle/0000_wooden_hellfire_club.sql
+++ b/services/api/drizzle/0000_wooden_hellfire_club.sql
@@ -260,8 +260,9 @@ CREATE TABLE IF NOT EXISTS "user" (
 	"user_name" varchar(23) NOT NULL,
 	"is_anonymous" boolean DEFAULT true NOT NULL,
 	"show_flagged_content" boolean DEFAULT false NOT NULL,
-	"post_count" integer DEFAULT 0 NOT NULL,
-	"comment_count" integer DEFAULT 0 NOT NULL,
+	"active_post_count" integer DEFAULT 0 NOT NULL,
+	"total_post_count" integer DEFAULT 0 NOT NULL,
+	"total_comment_count" integer DEFAULT 0 NOT NULL,
 	"created_at" timestamp (0) DEFAULT now() NOT NULL,
 	"updated_at" timestamp (0) DEFAULT now() NOT NULL,
 	CONSTRAINT "user_user_name_unique" UNIQUE("user_name")

--- a/services/api/drizzle/meta/0000_snapshot.json
+++ b/services/api/drizzle/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "a55396ea-3d12-422a-987b-2f00d0a6b656",
+  "id": "674dbee3-4b9b-4409-8d8b-fa9d9667dd1b",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -2243,15 +2243,22 @@
           "notNull": true,
           "default": false
         },
-        "post_count": {
-          "name": "post_count",
+        "active_post_count": {
+          "name": "active_post_count",
           "type": "integer",
           "primaryKey": false,
           "notNull": true,
           "default": 0
         },
-        "comment_count": {
-          "name": "comment_count",
+        "total_post_count": {
+          "name": "total_post_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_comment_count": {
+          "name": "total_comment_count",
           "type": "integer",
           "primaryKey": false,
           "notNull": true,

--- a/services/api/drizzle/meta/_journal.json
+++ b/services/api/drizzle/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1733170693968,
-      "tag": "0000_brief_unus",
+      "when": 1733236797067,
+      "tag": "0000_wooden_hellfire_club",
       "breakpoints": true
     }
   ]

--- a/services/api/openapi-zkorum.json
+++ b/services/api/openapi-zkorum.json
@@ -496,10 +496,6 @@
                                 "schema": {
                                     "type": "object",
                                     "properties": {
-                                        "commentCount": {
-                                            "type": "number",
-                                            "minimum": 0
-                                        },
                                         "postCount": {
                                             "type": "number",
                                             "minimum": 0
@@ -514,7 +510,6 @@
                                         }
                                     },
                                     "required": [
-                                        "commentCount",
                                         "postCount",
                                         "createdAt",
                                         "userName"

--- a/services/api/openapi-zkorum.json
+++ b/services/api/openapi-zkorum.json
@@ -1045,6 +1045,35 @@
                 }
             }
         },
+        "/api/v1/comment/delete": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "commentSlugId": {
+                                        "type": "string",
+                                        "maxLength": 10
+                                    }
+                                },
+                                "required": [
+                                    "commentSlugId"
+                                ],
+                                "additionalProperties": false
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Default Response"
+                    }
+                }
+            }
+        },
         "/api/v1/comment/create": {
             "post": {
                 "requestBody": {

--- a/services/api/openapi-zkorum.json
+++ b/services/api/openapi-zkorum.json
@@ -496,7 +496,7 @@
                                 "schema": {
                                     "type": "object",
                                     "properties": {
-                                        "postCount": {
+                                        "activePostCount": {
                                             "type": "number",
                                             "minimum": 0
                                         },
@@ -510,7 +510,7 @@
                                         }
                                     },
                                     "required": [
-                                        "postCount",
+                                        "activePostCount",
                                         "createdAt",
                                         "userName"
                                     ],

--- a/services/api/src/schema.ts
+++ b/services/api/src/schema.ts
@@ -572,8 +572,9 @@ export const userTable = pgTable("user", {
     userName: varchar("user_name", { length: MAX_LENGTH_USERNAME }).notNull().unique(),
     isAnonymous: boolean("is_anonymous").notNull().default(true),
     showFlaggedContent: boolean("show_flagged_content").notNull().default(false),
-    postCount: integer("post_count").notNull().default(0),
-    commentCount: integer("comment_count").notNull().default(0),
+    activePostCount: integer("active_post_count").notNull().default(0), // total posts (without deleted posts)
+    totalPostCount: integer("total_post_count").notNull().default(0), // total posts created
+    totalCommentCount: integer("total_comment_count").notNull().default(0), // total comments created
     createdAt: timestamp("created_at", {
         mode: "date",
         precision: 0,

--- a/services/api/src/service/comment.ts
+++ b/services/api/src/service/comment.ts
@@ -276,7 +276,7 @@ export async function postNewComment({
         await tx
             .update(userTable)
             .set({
-                commentCount: sql`${userTable.commentCount} + 1`
+                totalCommentCount: sql`${userTable.totalCommentCount} + 1`
             })
             .where(eq(userTable.id, userId));
 

--- a/services/api/src/service/post.ts
+++ b/services/api/src/service/post.ts
@@ -1,6 +1,6 @@
 // Interact with a post
 import { type PostgresJsDatabase as PostgresDatabase } from "drizzle-orm/postgres-js";
-import { pollTable, postContentTable, postProofTable, postTable, userTable } from "@/schema.js";
+import {  pollTable, postContentTable, postProofTable, postTable, userTable } from "@/schema.js";
 import { eq, sql, and } from "drizzle-orm";
 import type { CreateNewPostResponse } from "@/shared/types/dto.js";
 import { MAX_LENGTH_BODY } from "@/shared/shared.js";

--- a/services/api/src/service/post.ts
+++ b/services/api/src/service/post.ts
@@ -105,7 +105,8 @@ export async function createNewPost({
             await tx
                 .update(userTable)
                 .set({
-                    postCount: sql`${userTable.postCount} + 1`
+                    activePostCount: sql`${userTable.activePostCount} + 1`,
+                    totalPostCount: sql`${userTable.totalPostCount} + 1`,
                 })
                 .where(eq(userTable.id, authorId));
         });
@@ -187,7 +188,7 @@ export async function deletePostBySlugId({
             await tx
                 .update(userTable)
                 .set({
-                    postCount: sql`${userTable.postCount} - 1`,
+                    activePostCount: sql`${userTable.activePostCount} - 1`,
                 })
                 .where(eq(userTable.id, userId));
             

--- a/services/api/src/service/user.ts
+++ b/services/api/src/service/user.ts
@@ -53,8 +53,7 @@ export async function getUserComments({
       )
       .where(and(
         eq(commentTable.authorId, userId),
-        lt(commentTable.createdAt, lastCreatedAt),
-        isNotNull(postTable.currentContentId)))
+        lt(commentTable.createdAt, lastCreatedAt)))
       .orderBy(desc(commentTable.createdAt))
       .limit(10);
     

--- a/services/api/src/service/user.ts
+++ b/services/api/src/service/user.ts
@@ -3,7 +3,7 @@ import { commentContentTable, commentTable, postTable, userTable } from "@/schem
 import type { FetchUserProfileResponse } from "@/shared/types/dto.js";
 import type { CommentItem, ExtendedComment, ExtendedPost } from "@/shared/types/zod.js";
 import { httpErrors } from "@fastify/sensible";
-import { and, eq, lt, desc } from "drizzle-orm";
+import { and, eq, lt, desc, isNotNull } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { useCommonPost } from "./common.js";
 import { getPostSlugIdLastCreatedAt } from "./feed.js";
@@ -51,7 +51,7 @@ export async function getUserComments({
         postTable,
         eq(postTable.id, commentTable.postId)
       )
-      .where(and(eq(commentTable.authorId, userId), lt(commentTable.createdAt, lastCreatedAt)))
+      .where(and(eq(commentTable.authorId, userId), lt(commentTable.createdAt, lastCreatedAt), isNotNull(postTable.currentContentId)))
       .orderBy(desc(commentTable.createdAt))
       .limit(10);
     
@@ -146,7 +146,6 @@ export async function getUserProfile({
   try {
     const userTableResponse = await db
       .select({
-        commentCount: userTable.commentCount,
         postCount: userTable.postCount,
         createdAt: userTable.createdAt,
         userName: userTable.userName
@@ -160,7 +159,6 @@ export async function getUserProfile({
       );
     } else {
       return {
-        commentCount: userTableResponse[0].commentCount,
         postCount: userTableResponse[0].postCount,
         createdAt: userTableResponse[0].createdAt,
         userName: userTableResponse[0].userName,

--- a/services/api/src/service/user.ts
+++ b/services/api/src/service/user.ts
@@ -146,7 +146,7 @@ export async function getUserProfile({
   try {
     const userTableResponse = await db
       .select({
-        postCount: userTable.postCount,
+        activePostCount: userTable.activePostCount,
         createdAt: userTable.createdAt,
         userName: userTable.userName
       })
@@ -159,7 +159,7 @@ export async function getUserProfile({
       );
     } else {
       return {
-        postCount: userTableResponse[0].postCount,
+        activePostCount: userTableResponse[0].activePostCount,
         createdAt: userTableResponse[0].createdAt,
         userName: userTableResponse[0].userName,
       };

--- a/services/api/src/service/user.ts
+++ b/services/api/src/service/user.ts
@@ -3,7 +3,7 @@ import { commentContentTable, commentTable, postTable, userTable } from "@/schem
 import type { FetchUserProfileResponse } from "@/shared/types/dto.js";
 import type { CommentItem, ExtendedComment, ExtendedPost } from "@/shared/types/zod.js";
 import { httpErrors } from "@fastify/sensible";
-import { and, eq, lt, desc, isNotNull } from "drizzle-orm";
+import { and, eq, lt, desc } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { useCommonPost } from "./common.js";
 import { getPostSlugIdLastCreatedAt } from "./feed.js";

--- a/services/api/src/service/user.ts
+++ b/services/api/src/service/user.ts
@@ -45,13 +45,16 @@ export async function getUserComments({
       )
       .innerJoin(
         userTable,
-        eq(userTable.id, userId)
+        eq(userTable.id, commentTable.authorId)
       )
       .innerJoin(
         postTable,
         eq(postTable.id, commentTable.postId)
       )
-      .where(and(eq(commentTable.authorId, userId), lt(commentTable.createdAt, lastCreatedAt), isNotNull(postTable.currentContentId)))
+      .where(and(
+        eq(commentTable.authorId, userId),
+        lt(commentTable.createdAt, lastCreatedAt),
+        isNotNull(postTable.currentContentId)))
       .orderBy(desc(commentTable.createdAt))
       .limit(10);
     

--- a/services/api/src/shared/types/dto.ts
+++ b/services/api/src/shared/types/dto.ts
@@ -139,7 +139,7 @@ export class Dto {
         chosenOption: zodVotingAction
     }).strict();
     static fetchUserProfileResponse = z.object({
-        postCount: z.number().gte(0),
+        activePostCount: z.number().gte(0),
         createdAt: z.date(),
         userName: zodUserName,
     }).strict();

--- a/services/api/src/shared/types/dto.ts
+++ b/services/api/src/shared/types/dto.ts
@@ -139,7 +139,6 @@ export class Dto {
         chosenOption: zodVotingAction
     }).strict();
     static fetchUserProfileResponse = z.object({
-        commentCount: z.number().gte(0),
         postCount: z.number().gte(0),
         createdAt: z.date(),
         userName: zodUserName,

--- a/services/api/src/shared/types/dto.ts
+++ b/services/api/src/shared/types/dto.ts
@@ -160,6 +160,11 @@ export class Dto {
             postSlugId: zodSlugId
         })
         .strict();
+    static deleteCommentBySlugIdRequest = z
+        .object({
+            commentSlugId: zodSlugId
+        })
+        .strict();
 }
 
 export type AuthenticateRequestBody = z.infer<

--- a/services/shared/src/types/dto.ts
+++ b/services/shared/src/types/dto.ts
@@ -138,7 +138,6 @@ export class Dto {
         chosenOption: zodVotingAction
     }).strict();
     static fetchUserProfileResponse = z.object({
-        commentCount: z.number().gte(0),
         postCount: z.number().gte(0),
         createdAt: z.date(),
         userName: zodUserName,

--- a/services/shared/src/types/dto.ts
+++ b/services/shared/src/types/dto.ts
@@ -138,7 +138,7 @@ export class Dto {
         chosenOption: zodVotingAction
     }).strict();
     static fetchUserProfileResponse = z.object({
-        postCount: z.number().gte(0),
+        activePostCount: z.number().gte(0),
         createdAt: z.date(),
         userName: zodUserName,
     }).strict();

--- a/services/shared/src/types/dto.ts
+++ b/services/shared/src/types/dto.ts
@@ -159,6 +159,11 @@ export class Dto {
             postSlugId: zodSlugId
         })
         .strict();
+    static deleteCommentBySlugIdRequest = z
+        .object({
+            commentSlugId: zodSlugId
+        })
+        .strict();
 }
 
 export type AuthenticateRequestBody = z.infer<


### PR DESCRIPTION
Changes:
- Added a new delete comment API
- Revised the delete post API
  - Simplified the post ownership check
  - Delete post API will now delete all comments that belongs to the post
- Fixed a bug in the user profile tab where it is loading the wrong data